### PR TITLE
Fix #4: use-after-free of embeddedAddr in rs4_embed_cmsk()

### DIFF
--- a/import/chips/p9/utils/imageProcs/p9_scan_compression.C
+++ b/import/chips/p9/utils/imageProcs/p9_scan_compression.C
@@ -919,7 +919,6 @@ int
 rs4_embed_cmsk( CompressedScanData** io_rs4,
                 CompressedScanData*  i_rs4Cmsk )
 {
-    char* embeddedAddr = (char*)(*io_rs4 + 1);
     size_t embeddedSize = be16toh(i_rs4Cmsk->iv_size);
     size_t totalSize   = be16toh((*io_rs4)->iv_size) + embeddedSize;
 
@@ -930,6 +929,10 @@ rs4_embed_cmsk( CompressedScanData** io_rs4,
     {
         return BUG(SCAN_COMPRESSION_NO_MEMORY);
     }
+
+    // realloc() above may move the buffer, so derive the embedded address from
+    // the (possibly new) *io_rs4 pointer rather than from the pre-realloc one.
+    char* embeddedAddr = (char*)(*io_rs4 + 1);
 
     // Make space for cmsk ring
     memmove(embeddedAddr + embeddedSize,


### PR DESCRIPTION
`embeddedAddr` was derived from `*io_rs4` before `realloc()` may relocate the buffer, then dereferenced by `memmove()`/`memcpy()` afterwards. GCC reports this as `-Werror=use-after-free` (e.g. Fedora 39 / Ubuntu 26.04), failing the build, and it is a genuine latent bug regardless of the warning.

Move the `embeddedAddr` computation to after the `realloc()` so it is derived from the (possibly new) `*io_rs4` pointer.